### PR TITLE
DP-16870 Add trufflehog to pre-commit in servicebot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,12 @@ repos:
         types: [shell]
         exclude_types: [csh, perl, python, ruby, tcsh, zsh]
         args: [-e, SC1091]
+      - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets in your data
+        entry: trufflehog.sh git file://. --since-commit HEAD --results=verified --fail
+        language: script
+        pass_filenames: false
+        stages:
+          - pre-commit
+          - pre-push

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,9 @@
   language: script
   types: [shell]
   args: [-e, SC1091]
+- id: trufflehog
+  name: TruffleHog
+  description: Detect secrets in your data
+  entry: trufflehog.sh git file://. --since-commit HEAD --results=verified --fail
+  language: script
+  pass_filenames: false

--- a/trufflehog.sh
+++ b/trufflehog.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+# adapted from https://github.com/trufflesecurity/trufflehog/blob/main/scripts/install.sh
+# without the insecurity of `curl |sh`
+
+set -eu
+
+func_fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+
+
+# this function wraps all the destructive operations
+# if a curl|bash cuts off the end of the script due to
+# network, either nothing will happen or will syntax error
+# out preventing half-done work
+execute() {
+  tmpdir=$(mktemp -d)
+  log_debug "downloading files into ${tmpdir}"
+  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+
+  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  srcdir="${tmpdir}"
+  (cd "${tmpdir}" && untar "${TARBALL}")
+  mkdir -p "${BINDIR}"
+
+  binexe=${BINARY}
+  if [ "$OS" = "windows" ]; then
+    binexe="${binexe}.exe"
+  fi
+  install "${srcdir}/${binexe}" "${BINDIR}/"
+  log_info "installed ${BINDIR}/${binexe}"
+
+  rm -rf "${tmpdir}"
+}
+
+get_binary() {
+  case "$PLATFORM" in
+    darwin/amd64) BINARY="trufflehog" ;;
+    darwin/arm64) BINARY="trufflehog" ;;
+    linux/amd64) BINARY="trufflehog" ;;
+    linux/arm64) BINARY="trufflehog" ;;
+    windows/amd64) BINARY="trufflehog" ;;
+    windows/arm64) BINARY="trufflehog" ;;
+    *)
+      log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
+      exit 1
+      ;;
+  esac
+}
+
+tag_to_version() {
+  if [ -z "${TAG}" ]; then
+    log_info "checking GitHub for latest tag"
+  else
+    log_info "checking GitHub for tag '${TAG}'"
+  fi
+  REALTAG=$(github_release "$OWNER/$REPO" "${TAG}") || true
+  if test -z "$REALTAG"; then
+    log_crit "unable to find '${TAG}' - use 'latest' or see https://github.com/${PREFIX}/releases for details"
+    exit 1
+  fi
+  # if version starts with 'v', remove it
+  TAG="$REALTAG"
+  VERSION=${TAG#v}
+}
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+https://github.com/client9/shlib - portable posix shell functions
+Public domain - http://unlicense.org
+https://github.com/client9/shlib/blob/master/LICENSE.md
+but credit (and pull requests) appreciated.
+------------------------------------------------------------------------
+EOF
+
+is_command() {
+  command -v "$1" >/dev/null
+}
+
+echoerr() {
+  echo "$@" 1>&2
+}
+
+_logp=6
+log_set_priority() {
+  _logp="$1"
+}
+
+log_priority() {
+  if test -z "$1"; then
+    echo "$_logp"
+    return
+  fi
+  [ "$1" -le "$_logp" ]
+}
+
+log_tag() {
+  case $1 in
+    0) echo "emerg" ;;
+    1) echo "alert" ;;
+    2) echo "crit" ;;
+    3) echo "err" ;;
+    4) echo "warning" ;;
+    5) echo "notice" ;;
+    6) echo "info" ;;
+    7) echo "debug" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+log_debug() {
+  log_priority 7 || return 0
+  echo "$(log_prefix)" "$(log_tag 7)" "$@"
+}
+
+log_info() {
+  log_priority 6 || return 0
+  echo "$(log_prefix)" "$(log_tag 6)" "$@"
+}
+
+log_err() {
+  log_priority 3 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
+}
+
+log_crit() {
+  log_priority 2 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
+}
+
+uname_os() {
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$os" in
+    cygwin_nt*) os="windows" ;;
+    mingw*) os="windows" ;;
+    msys_nt*) os="windows" ;;
+  esac
+  echo "$os"
+}
+
+uname_arch() {
+  arch=$(uname -m)
+  case $arch in
+    x86_64) arch="amd64" ;;
+    aarch64) arch="arm64" ;;
+  esac
+  echo "$arch"
+}
+
+uname_os_check() (
+  os=$1
+  case "$os" in
+    darwin) return 0 ;;
+    dragonfly) return 0 ;;
+    freebsd) return 0 ;;
+    linux) return 0 ;;
+    android) return 0 ;;
+    nacl) return 0 ;;
+    netbsd) return 0 ;;
+    openbsd) return 0 ;;
+    plan9) return 0 ;;
+    solaris) return 0 ;;
+    windows) return 0 ;;
+  esac
+  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
+  return 1
+)
+
+uname_arch_check() (
+  arch=$1
+  case "$arch" in
+    386) return 0 ;;
+    amd64) return 0 ;;
+    arm64) return 0 ;;
+    armv5) return 0 ;;
+    armv6) return 0 ;;
+    armv7) return 0 ;;
+    ppc64) return 0 ;;
+    ppc64le) return 0 ;;
+    mips) return 0 ;;
+    mipsle) return 0 ;;
+    mips64) return 0 ;;
+    mips64le) return 0 ;;
+    s390x) return 0 ;;
+    amd64p32) return 0 ;;
+  esac
+  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
+  return 1
+)
+
+untar() {
+  tarball=$1
+  case "${tarball}" in
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+    *.tar) tar --no-same-owner -xf "${tarball}" ;;
+    *.zip) unzip "${tarball}" ;;
+    *)
+      log_err "untar unknown archive format for ${tarball}"
+      return 1
+      ;;
+  esac
+}
+
+http_download_curl() {
+  local_file=$1
+  source_url=$2
+  header=${3-}
+  if [ -z "$header" ]; then
+    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+  else
+    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+  fi
+  if [ "$code" != "200" ]; then
+    log_err "http_download_curl received HTTP status $code"
+    return 1
+  fi
+  return 0
+}
+
+http_download_wget() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    wget -q -O "$local_file" "$source_url"
+  else
+    wget -q --header "$header" -O "$local_file" "$source_url"
+  fi
+}
+
+http_download() {
+  log_debug "http_download $2"
+  if is_command curl; then
+    http_download_curl "$@"
+    return
+  elif is_command wget; then
+    http_download_wget "$@"
+    return
+  fi
+  log_crit "http_download unable to find wget or curl"
+  return 1
+}
+
+http_copy() {
+  tmp=$(mktemp)
+  http_download "${tmp}" "$1" "$2" || return 1
+  body=$(cat "$tmp")
+  rm -f "${tmp}"
+  echo "$body"
+}
+
+github_release() {
+  owner_repo=$1
+  version=$2
+  test -z "$version" && version="latest"
+  giturl="https://github.com/${owner_repo}/releases/${version}"
+  json=$(http_copy "$giturl" "Accept:application/json")
+  test -z "$json" && return 1
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  test -z "$version" && return 1
+  echo "$version"
+}
+
+hash_sha256() {
+  TARGET=${1:-/dev/stdin}
+  if is_command gsha256sum; then
+    hash=$(gsha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command sha256sum; then
+    hash=$(sha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command shasum; then
+    hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command openssl; then
+    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f a
+  else
+    log_crit "hash_sha256 unable to find command to compute sha-256 hash"
+    return 1
+  fi
+}
+
+hash_sha256_verify() {
+  TARGET=$1
+  checksums=$2
+  if [ -z "$checksums" ]; then
+    log_err "hash_sha256_verify checksum file not specified in arg2"
+    return 1
+  fi
+  BASENAME=${TARGET##*/}
+  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  if [ -z "$want" ]; then
+    log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
+    return 1
+  fi
+  got=$(hash_sha256 "$TARGET")
+  if [ "$want" != "$got" ]; then
+    log_err "hash_sha256_verify checksum for '$TARGET' did not verify ${want} vs $got"
+    return 1
+  fi
+}
+
+
+PROJECT_NAME="trufflehog"
+OWNER=trufflesecurity
+REPO="trufflehog"
+FORMAT=tar.gz
+OS=$(uname_os)
+ARCH=$(uname_arch)
+PREFIX="$OWNER/$REPO"
+PLATFORM="${OS}/${ARCH}"
+GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+TAG=v3.90.2
+
+
+# use in logging routines
+log_prefix() {
+	echo "$PREFIX"
+}
+
+
+
+: "${BINDIR=$HOME/bin}"
+
+if ! is_command trufflehog; then
+    if is_command brew; then
+        brew install trufflehog
+    else
+        uname_os_check "$OS"
+        uname_arch_check "$ARCH"
+
+        get_binary
+        tag_to_version
+        log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
+
+        NAME=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+        TARBALL=${NAME}.${FORMAT}
+        TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
+        CHECKSUM=${PROJECT_NAME}_${VERSION}_checksums.txt
+        CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
+
+        execute
+    fi
+
+    export PATH=$PATH:$BINDIR
+    hash -r
+fi
+
+trufflehog "$@"


### PR DESCRIPTION
- trufflehog binaries are not widely available; and the `curl |sh` recommendation on their website makes for bad security
- I've adapted https://github.com/trufflesecurity/trufflehog/blob/main/scripts/install.sh to a self-installing wrapper for our devprod pre-commit hooks repo so we'll be able to leverage that from the servicebot pre-commit template

# Testing

https://semaphore.ci.confluent.io/jobs/8a162eed-c8bb-43e0-8b27-55e0d39bff64#L196